### PR TITLE
Fetch runtime environment variables on startup

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,47 +2,55 @@
 
 const express = require("express");
 const log4js = require("log4js");
+const initializeDatabase = require("./db-factory");
 
 const config = require("./config");
-require("./db-factory");
 
 const PORT = process.env.PORT || 10010;
-const TIMEOUT = process.env.API_REQUEST_TIMEOUT || 120;
+(async () => {
+    try {
+        // Wait for the initializeDatabase function to resolve and get envVariables
+        const envVariables = await initializeDatabase();
 
-const app = express();
-const logger = log4js.getLogger(global.loggerName);
-global.logger = logger;
+        const TIMEOUT = envVariables.API_REQUEST_TIMEOUT || 120;
 
-app.use(express.urlencoded({ extended: true }));
-app.use(express.json({ limit: "5mb" }));
+        const app = express();
+        const logger = log4js.getLogger(global.loggerName);
+        global.logger = logger;
 
-app.use(function (req, res, next) {
-    if (req.path.indexOf("health") == -1) {
-        logger.info("Request Recieved", req.method, req.path);
+        app.use(express.urlencoded({ extended: true }));
+        app.use(express.json({ limit: "5mb" }));
+
+        app.use(function (req, res, next) {
+            if (req.path.indexOf("health") == -1) {
+                logger.info("Request Received", req.method, req.path);
+            }
+            next();
+        });
+
+        app.use("/ne", require("./controllers"));
+
+        if (config.isK8sEnv()) {
+            logger.info("*** K8s environment detected ***");
+            logger.info("Image version: " + process.env.IMAGE_TAG);
+        } else {
+            logger.info("*** Local environment detected ***");
+        }
+
+        logger.info(`Hook :: Retry limit :: ${config.retryCounter.webHooks}`);
+        logger.info(`Hook :: Retry delay :: ${config.retryDelay.webHooks}ms`);
+
+        const server = app.listen(PORT, (err) => {
+            if (!err) {
+                logger.info("Server started on port " + PORT);
+            } else {
+                logger.error(err);
+                process.exit(0);
+            }
+        });
+
+        server.setTimeout(parseInt(TIMEOUT) * 1000);
+    } catch (error) {
+        console.error("Error initializing envVariables:", error);
     }
-    next();
-});
-
-app.use("/ne", require("./controllers"));
-
-if (config.isK8sEnv()) {
-    logger.info("*** K8s environment detected ***");
-    logger.info("Image version: " + process.env.IMAGE_TAG);
-} else {
-    logger.info("*** Local environment detected ***");
-}
-
-logger.info(`Hook :: Retry limit :: ${config.retryCounter.webHooks}`);
-logger.info(`Hook :: Retry delay :: ${config.retryDelay.webHooks}ms`);
-
-
-const server = app.listen(PORT, (err) => {
-    if (!err) {
-        logger.info("Server started on port " + PORT);
-    } else {
-        logger.error(err);
-        process.exit(0);
-    }
-});
-
-server.setTimeout(parseInt(TIMEOUT) * 1000);
+})();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Jugnu Agrawal",
   "license": "ISC",
   "dependencies": {
-    "@appveen/data.stack-utils": "^1.0.22",
+    "@appveen/data.stack-utils": "github:appveen/data.stack-utils",
     "@appveen/swagger-mongoose-crud": "^2.0.1",
     "@appveen/utils": "^2.2.1",
     "express": "^4.18.2",

--- a/utils/web-hook.utils.js
+++ b/utils/web-hook.utils.js
@@ -70,7 +70,7 @@ async function processMessageOnHooksChannel(data, client) {
 async function postWebHook(data) {
     let txnId = data.txnId;
     try {
-        let timeout = (process.env.HOOK_CONNECTION_TIMEOUT && parseInt(process.env.HOOK_CONNECTION_TIMEOUT)) || 30;
+        let timeout = (config.HOOK_CONNECTION_TIMEOUT && parseInt(config.HOOK_CONNECTION_TIMEOUT)) || 30;
         data["headers"]["Content-Type"] = "application/json";
         let payload = JSON.parse(JSON.stringify(data));
         delete payload._metadata;


### PR DESCRIPTION
- At startup, fetch environment variables from the database. If not found, crash the component.
- Restructed `app.js` to wait for the `initializeDatabase` function to obtain envVariables and then proceeds with setting up the Express app and starting the server. 